### PR TITLE
remove comments in evolutions/1.sql to fix sqlite support

### DIFF
--- a/conf/evolutions/default/1.sql
+++ b/conf/evolutions/default/1.sql
@@ -79,15 +79,6 @@ create table deployment_log (
     last_update timestamp not null,
     result int not null
 );
--- target_platform
--- ~~~~~~~~~~~~~~~
--- 'PRELIVE' - deployment done to a staging or pre-live environment (only possible, if activated, see README.md)
--- 'LIVE' - deployment done to the live environment
---
--- result
--- ~~~~~~
--- 0 - OK
--- 1 - ERROR
 
 # --- !Downs
 


### PR DESCRIPTION
The Docker image resulting from #10 won't run sucessfully unless this patch is applied to the evolution -- it would throw `[error] p.a.d.e.DefaultEvolutionsApi - The prepared statement has been finalized [ERROR:0, SQLSTATE:null]
Oops, cannot start the server`