### PR TITLE
pull remaining build.sbt runtime options into Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ docker-build:
 
 docker-run:
 	mkdir -p var
-	docker run -v$(pwd)/var:/var/smui -p9000:9000 --rm -it --name smui \
+	docker run -v`pwd`/var:/var/smui -p9000:9000 --rm -it --name smui \
 		-eSMUI_DB_URL=jdbc:sqlite:/var/smui/test.db -eSMUI_DB_JDBC_DRIVER=org.sqlite.JDBC \
 		$(IMAGE):$(VERSION)
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -32,7 +32,18 @@ ENV SMUI_VERSION=$VERSION
 WORKDIR /smui
 
 COPY --from=builder /smui/target/scala-$SCALA_VERSION/search-management-ui-assembly-$VERSION.jar .
+COPY conf/logback.xml /smui/logback.xml
 
-EXPOSE 9000
+ENV SMUI_CONF_PID_PATH=/var/run/play.pid
+ENV SMUI_CONF_LOG_BASE_PATH=/var/log
+ENV SMUI_CONF_HTTP_PORT=9000
+ENV SMUI_CONF_LOGBACK_XML_PATH=/smui/logback.xml
 
-CMD java -jar /smui/search-management-ui-assembly-$SMUI_VERSION.jar
+EXPOSE $SMUI_CONF_HTTP_PORT
+
+CMD java \
+  -Dpidfile.path=$SMUI_CONF_PID_PATH \
+  -DLOG_BASE_PATH=$SMUI_CONF_LOG_BASE_PATH \
+  -Dlogback.configurationFile=$SMUI_CONF_LOGBACK_XML_PATH \
+  -Dhttp.port=$SMUI_CONF_HTTP_PORT \
+  -jar /smui/search-management-ui-assembly-$SMUI_VERSION.jar


### PR DESCRIPTION
`build.sbt` contains some variables that could be customised using a shell fragment (in RPM-based installs). This PR pulls them into `Dockerfile` to make them controllable via environment for Docker users.
```
ENV SMUI_CONF_PID_PATH=/var/run/play.pid
ENV SMUI_CONF_LOG_BASE_PATH=/var/log
ENV SMUI_CONF_HTTP_PORT=9000
ENV SMUI_CONF_LOGBACK_XML_PATH=/smui/logback.xml
```

On the way, fixed a volume-mount issue in Makefile target `docker-run`.