### PR TITLE
Fix loading list of inputs with synonyms and tags

### DIFF
--- a/app/models/SearchInputWithRules.scala
+++ b/app/models/SearchInputWithRules.scala
@@ -41,6 +41,21 @@ object SearchInputWithRules {
     }
   }
 
+  /**
+    * For displaying a list of search inputs with only some properties set.
+    */
+  def loadWithUndirectedSynonymsAndTagsForSolrIndexId(solrIndexId: SolrIndexId)(implicit connection: Connection): List[SearchInputWithRules] = {
+    val inputs = SearchInput.loadAllForIndex(solrIndexId)
+    val rules = SynonymRule.loadUndirectedBySearchInputIds(inputs.map(_.id))
+    val tags = TagInputAssociation.loadTagsBySearchInputIds(inputs.map(_.id))
+
+    inputs.map { input =>
+      SearchInputWithRules(input.id, input.term,
+        synonymRules = rules.getOrElse(input.id, Nil).toList,
+        tags = tags.getOrElse(input.id, Seq.empty))
+    }
+  }
+
   def update(searchInput: SearchInputWithRules)(implicit connection: Connection): Unit = {
     SearchInput.update(searchInput.id, searchInput.term)
 

--- a/app/models/SearchManagementRepository.scala
+++ b/app/models/SearchManagementRepository.scala
@@ -69,15 +69,7 @@ class SearchManagementRepository @Inject()(dbapi: DBApi, toggleService: FeatureT
     */
   def listAllSearchInputsInclDirectedSynonyms(solrIndexId: SolrIndexId): List[SearchInputWithRules] = {
     db.withConnection { implicit connection =>
-      val inputs = SearchInput.loadAllForIndex(solrIndexId)
-      val rules = SynonymRule.loadUndirectedBySearchInputIds(inputs.map(_.id))
-      val tags = TagInputAssociation.loadTagsBySearchInputIds(inputs.map(_.id))
-
-      inputs.map { input =>
-        SearchInputWithRules(input.id, input.term,
-          synonymRules = rules.getOrElse(input.id, Nil).toList,
-          tags = tags.getOrElse(input.id, Seq.empty))
-      }
+      SearchInputWithRules.loadWithUndirectedSynonymsAndTagsForSolrIndexId(solrIndexId)
     }
   }
 

--- a/app/models/TagInputAssociation.scala
+++ b/app/models/TagInputAssociation.scala
@@ -56,7 +56,7 @@ object TagInputAssociation {
     ids.grouped(100).toSeq.flatMap { idGroup =>
       SQL(s"select * from $TABLE_NAME a, ${InputTag.TABLE_NAME} t where a.$INPUT_ID in ({inputIds}) " +
         s"and a.$TAG_ID = t.${InputTag.ID} order by t.${InputTag.PROPERTY} asc, t.${InputTag.VALUE} asc").
-        on("inputIds" -> ids).as((InputTag.sqlParser ~ get[SearchInputId](s"$TABLE_NAME.$INPUT_ID")).*).
+        on("inputIds" -> idGroup).as((InputTag.sqlParser ~ get[SearchInputId](s"$TABLE_NAME.$INPUT_ID")).*).
         map { case tag ~ inputId =>
           inputId -> tag
         }

--- a/app/models/rules/SynonymRule.scala
+++ b/app/models/rules/SynonymRule.scala
@@ -45,7 +45,7 @@ object SynonymRule extends RuleObjectWithTerm[SynonymRule] {
 
   def loadUndirectedBySearchInputIds(ids: Seq[SearchInputId])(implicit connection: Connection): Map[SearchInputId, Seq[SynonymRule]] = {
     ids.grouped(100).toSeq.flatMap { idGroup =>
-      SQL"select * from #$TABLE_NAME where #$SEARCH_INPUT_ID in ($ids)".as((sqlParser ~ get[SearchInputId](SEARCH_INPUT_ID)).*).map { case rule ~ id =>
+      SQL"select * from #$TABLE_NAME where #$TYPE = #$TYPE_UNDIRECTED AND #$SEARCH_INPUT_ID in ($idGroup)".as((sqlParser ~ get[SearchInputId](SEARCH_INPUT_ID)).*).map { case rule ~ id =>
         id -> rule
       }
     }.groupBy(_._1).mapValues(_.map(_._2))

--- a/test/models/InputTagSpec.scala
+++ b/test/models/InputTagSpec.scala
@@ -4,21 +4,8 @@ import java.time.LocalDateTime
 
 import org.h2.jdbc.JdbcBatchUpdateException
 import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
-import play.api.db.evolutions.Evolutions
-import play.api.db.{Database, Databases}
 
-class InputTagSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
-
-  private var db: Database = _
-
-  override protected def beforeEach(): Unit = {
-    db = Databases.inMemory(config = Map("MODE" -> "MYSQL"))
-    Evolutions.applyEvolutions(db)
-  }
-
-  override protected def afterEach(): Unit = {
-    db.shutdown()
-  }
+class InputTagSpec extends FlatSpec with Matchers with BeforeAndAfterEach with WithInMemoryDB {
 
   private val index = SolrIndex(name = "de", description = "German")
   private val inputTags = Seq(

--- a/test/models/SearchInputWithRulesSpec.scala
+++ b/test/models/SearchInputWithRulesSpec.scala
@@ -1,0 +1,49 @@
+package models
+
+import java.sql.Connection
+
+import models.rules.{SynonymRule, SynonymRuleId}
+import org.scalatest.{FlatSpec, Matchers}
+
+class SearchInputWithRulesSpec extends FlatSpec with Matchers with WithInMemoryDB {
+
+  private val indexDe = SolrIndex(name = "de", description = "German")
+  private val indexEn = SolrIndex(name = "en", description = "English")
+  private val tag = InputTag.create(None, Some("tenant"), "MO", exported = true)
+
+  "SearchInputWithRules" should "load lists with hundreds of entries successfully" in {
+    db.withConnection { implicit conn =>
+      SolrIndex.insert(indexDe)
+      SolrIndex.insert(indexEn)
+      InputTag.insert(tag)
+
+      insertInputs(300, indexDe.id, "term_de")
+      insertInputs(200, indexEn.id, "term_en")
+
+      val inputsDe = SearchInputWithRules.loadWithUndirectedSynonymsAndTagsForSolrIndexId(indexDe.id)
+      inputsDe.size shouldBe 300
+      for (input <- inputsDe) {
+        input.term should startWith("term_de_")
+        input.tags.size shouldBe 1
+        input.tags.head.displayValue shouldBe "tenant:MO"
+        input.synonymRules.size shouldBe 1 // Only undirected synonyms should be loaded
+        input.synonymRules.head.term should startWith("term_de_synonym_")
+      }
+
+      SearchInputWithRules.loadWithUndirectedSynonymsAndTagsForSolrIndexId(indexEn.id).size shouldBe 200
+    }
+  }
+
+  private def insertInputs(count: Int, indexId: SolrIndexId, termPrefix: String)(implicit conn: Connection): Unit = {
+    for (i <- 0 until count) {
+      val input = SearchInput.insert(indexId, s"${termPrefix}_$i")
+      SynonymRule.updateForSearchInput(input.id, Seq(
+        SynonymRule(SynonymRuleId(), SynonymRule.TYPE_UNDIRECTED, s"${termPrefix}_synonym_$i", isActive = true),
+        SynonymRule(SynonymRuleId(), SynonymRule.TYPE_DIRECTED, s"${termPrefix}_directedsyn_$i", isActive = true),
+      ))
+      TagInputAssociation.updateTagsForSearchInput(input.id, Seq(tag.id))
+    }
+  }
+
+
+}

--- a/test/models/WithInMemoryDB.scala
+++ b/test/models/WithInMemoryDB.scala
@@ -1,0 +1,20 @@
+package models
+
+import org.scalatest.{BeforeAndAfterEach, Suite}
+import play.api.db.{Database, Databases}
+import play.api.db.evolutions.Evolutions
+
+trait WithInMemoryDB extends BeforeAndAfterEach { self: Suite =>
+
+  protected var db: Database = _
+
+  override protected def beforeEach(): Unit = {
+    db = Databases.inMemory(config = Map("MODE" -> "MYSQL"))
+    Evolutions.applyEvolutions(db)
+  }
+
+  override protected def afterEach(): Unit = {
+    db.shutdown()
+  }
+
+}


### PR DESCRIPTION
- When lists were longer than 100 entries, synonyms and tags very loaded multiple times for each input
- Directed synonyms were loaded, too (only undirected ones should be displayed in the list)
- Adds a test for loading a long list of inputs