### PR TITLE
Add dependency check plugin to sbt and fix some open vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ SMUI is a tool for managing Solr-based onsite search. It provides a web user int
 You can use `make` to build and run SMUI as or into a docker container (see [Makefile](Makefile)), e.g. (command line):
 
 ```
-make docker-build
+make docker-build-only
 make docker-run
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import com.typesafe.sbt.GitBranchPrompt
 import com.typesafe.sbt.packager.rpm.RpmPlugin.autoImport.{rpmBrpJavaRepackJars, rpmLicense}
 
 name := "search-management-ui"
-version := "3.1.0"
+version := "3.2.0"
 
 scalaVersion := "2.12.4"
 
@@ -30,6 +30,7 @@ lazy val root = (project in file("."))
   )
 
   .settings(packagingSettings: _*)
+  .settings(dependencyCheckSettings: _*)
   .settings(
     publishArtifact in (Compile, packageDoc) := false,
     publishArtifact in packageDoc := false,
@@ -97,6 +98,15 @@ lazy val root = (project in file("."))
 updateOptions := updateOptions.value.withCachedResolution(cachedResoluton = true)
 // we use nodejs to make our typescript build as fast as possible
 JsEngineKeys.engineType := JsEngineKeys.EngineType.Node
+
+lazy val dependencyCheckSettings: Seq[Setting[_]] = {
+  import DependencyCheckPlugin.autoImport._
+  Seq(
+    dependencyCheckSuppressionFile := Some(new File("suppress-checks.xml").getAbsoluteFile),
+    dependencyCheckFormats := Seq("HTML", "JSON"),
+    dependencyCheckAssemblyAnalyzerEnabled := Some(false)
+  )
+}
 
 resolvers ++= Seq(
   Resolver.jcenterRepo,

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import com.typesafe.sbt.GitBranchPrompt
 import com.typesafe.sbt.packager.rpm.RpmPlugin.autoImport.{rpmBrpJavaRepackJars, rpmLicense}
 
 name := "search-management-ui"
-version := "3.2.0"
+version := "3.2.1"
 
 scalaVersion := "2.12.4"
 
@@ -135,7 +135,7 @@ libraryDependencies ++= {
 
     // Additional Play Framework Dependencies
 
-    "mysql" % "mysql-connector-java" % "8.0.13", // TODO verify use of mysql-connector over explicit mariaDB connector instead
+    "mysql" % "mysql-connector-java" % "8.0.18", // TODO verify use of mysql-connector over explicit mariaDB connector instead
     "org.postgresql" % "postgresql" % "42.2.5",
     "org.xerial" % "sqlite-jdbc" % "3.25.2",
     "org.playframework.anorm" %% "anorm" % "2.6.4",
@@ -193,10 +193,17 @@ libraryDependencies ++= {
     "org.xerial" % "sqlite-jdbc" % "3.28.0" % Test
   )
 }
-dependencyOverrides ++= Seq(
-  "org.webjars.npm" % "minimatch" % "3.0.0",
-  "org.webjars.npm" % "glob" % "7.1.2"
-)
+
+
+dependencyOverrides ++= {
+  lazy val jacksonVersion = "2.9.10"
+  Seq(
+    "org.webjars.npm" % "minimatch" % "3.0.0",
+    "org.webjars.npm" % "glob" % "7.1.2",
+    "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
+    "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion
+  )
+}
 
 // use the webjars npm directory (target/web/node_modules ) for resolution of module imports of angular2/core etc
 resolveFromWebjarsNodeModulesDir := true

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -27,6 +27,4 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 
-
-//
-//addSbtPlugin("net.virtual-void" % "sbt-optimizer" % "0.1.2")
+addSbtPlugin("net.vonbuchholtz" % "sbt-dependency-check" % "1.3.3")

--- a/suppress-checks.xml
+++ b/suppress-checks.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
+</suppressions>

--- a/suppress-checks.xml
+++ b/suppress-checks.xml
@@ -1,3 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes><![CDATA[
+        False positive
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/tyrex/tyrex@.*$</packageUrl>
+        <cve>CVE-2009-2704</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        False positive
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/tyrex/tyrex@.*$</packageUrl>
+        <cve>CVE-2009-2705</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
There are still a number of open vulnerabilities. Most of them reside in the webjars, but there are also three jackson-databind vulnerabilities (all of them HIGH) remaining. I only bumped to jackson 2.9.10 to ensure compatibility and fix a `CRITICAL` vulnerability. You might want to bump that even further.

To run the checks, just run
`sbt dependencyCheck` and look for the file `dependency-check-report.html` in the target directory.